### PR TITLE
Adds OpenAPI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3-jdk-8 as builder
-COPY . /tmp/atlas
-WORKDIR /tmp/atlas
-RUN mvn package -DskipTests && mkdir /build && unzip /tmp/atlas/org.planqk.atlas.web/target/org.planqk.atlas.web.war -d /build/atlas
+COPY . /tmp/nisq
+WORKDIR /tmp/nisq
+RUN mvn package -DskipTests && mkdir /build && unzip /tmp/nisq/org.planqk.nisq.analyzer.core/target/org.planqk.nisq.analyzer.core.war -d /build/nisq-analyzer
 
 FROM ubuntu:18.04
 LABEL maintainer = "Benjamin Weder <benjamin.weder@iaas.uni-stuttgart.de>"
@@ -11,9 +11,13 @@ ARG TOMCAT_VERSION=9.0.8
 
 ENV POSTGRES_HOSTNAME localhost
 ENV POSTGRES_PORT 5432
-ENV POSTGRES_USER postgres
-ENV POSTGRES_PASSWORD postgres
-ENV POSTGRES_DB postgres
+ENV POSTGRES_USER nisq
+ENV POSTGRES_PASSWORD nisq
+ENV POSTGRES_DB nisq
+
+ENV NISQ_HOSTNAME: localhost
+ENV NISQ_PORT: 5000
+ENV NISQ_VERSION: v1.0
 
 RUN apt-get -qq update && apt-get install -qqy software-properties-common openjdk-8-jdk wget
 
@@ -36,12 +40,12 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN rm -rf ${CATALINA_HOME}/webapps/*
-COPY --from=builder /build/atlas ${CATALINA_HOME}/webapps/atlas
+COPY --from=builder /build/nisq-analyzer ${CATALINA_HOME}/webapps/nisq-analyzer
 
 EXPOSE 8080
 
 # configure application with template and docker environment variables
 ADD .docker/application.properties.tpl ${CATALINA_HOME}/webapps/application.properties.tpl
 
-CMD dockerize -template ${CATALINA_HOME}/webapps/application.properties.tpl:${CATALINA_HOME}/webapps/atlas/WEB-INF/classes/application.properties \
+CMD dockerize -template ${CATALINA_HOME}/webapps/application.properties.tpl:${CATALINA_HOME}/webapps/nisq-analyzer/WEB-INF/classes/application.properties \
     ${CATALINA_HOME}/bin/catalina.sh run

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/Application.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/Application.java
@@ -37,7 +37,6 @@ public class Application extends SpringBootServletInitializer {
      * Launch the embedded Tomcat server.
      *
      * See `application.properties` for its configuration.
-     * @param args
      */
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/Application.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/Application.java
@@ -1,7 +1,12 @@
 package org.planqk.nisq.analyzer.core;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
@@ -12,6 +17,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @SpringBootApplication(scanBasePackages = "org.planqk.nisq.analyzer.*")
 @EnableJpaRepositories("org.planqk.nisq.analyzer.*")
 @EntityScan("org.planqk.nisq.analyzer.*")
+@OpenAPIDefinition(info = @Info(title = "nisq-analyzer", version = "0.0", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), contact = @Contact(url = "https://github.com/PlanQK/nisq-analyzer", name = "GitHub Repository")))
 public class Application extends SpringBootServletInitializer {
 
     final private static Logger LOG = LoggerFactory.getLogger(Application.class);
@@ -25,5 +31,15 @@ public class Application extends SpringBootServletInitializer {
                 "NISQ Analyzer IS READY TO USE!\n" +
                 "===================================================";
         LOG.info(readyMessage);
+    }
+
+    /**
+     * Launch the embedded Tomcat server.
+     *
+     * See `application.properties` for its configuration.
+     * @param args
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
     }
 }

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/connector/QiskitSdkConnector.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/connector/QiskitSdkConnector.java
@@ -59,9 +59,9 @@ public class QiskitSdkConnector implements SdkConnector {
     private URI executeAPIEndpoint;
 
     public QiskitSdkConnector(
-            @Value("${org.planqk.nisq.analyzer.connector.qiskit.hostname}") String hostname,
-            @Value("${org.planqk.nisq.analyzer.connector.qiskit.port}") int port,
-            @Value("${org.planqk.nisq.analyzer.connector.qiskit.version}") String version
+            @Value("${NISQ_HOSTNAME}") String hostname,
+            @Value("${NISQ_PORT}") int port,
+            @Value("${NISQ_VERSION}") String version
     ) {
         // compile the API endpoints
         transpileAPIEndpoint = URI.create(String.format("http://%s:%d/qiskit-service/api/%s/transpile", hostname, port, version));

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/model/Implementation.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/model/Implementation.java
@@ -76,7 +76,7 @@ public class Implementation extends HasId {
     private List<ExecutionResult> executionResults;
 
     @Setter
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private List<Parameter> inputParameters;
 
     @Setter

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
@@ -22,6 +22,8 @@ package org.planqk.nisq.analyzer.core.web.controller;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.ExecutionResult;
 import org.planqk.nisq.analyzer.core.model.Implementation;
@@ -45,6 +47,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to retrieve the results of quantum algorithm implementation executions.
  */
+@io.swagger.v3.oas.annotations.tags.Tag(name = "execution-result")
 @RestController
 @RequestMapping("/" + Constants.IMPLEMENTATIONS + "/{implId}/" + Constants.RESULTS)
 public class ExecutionResultController {
@@ -59,6 +62,7 @@ public class ExecutionResultController {
         this.executionResultRepository = executionResultRepository;
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve all execution results for an Implementation")
     @GetMapping("/")
     public HttpEntity<ExecutionResultListDto> getExecutionResults(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve all execution results for impl with id: {}.", implId);
@@ -80,6 +84,7 @@ public class ExecutionResultController {
         return new ResponseEntity<>(dtoList, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single execution result")
     @GetMapping("/{resultId}")
     public HttpEntity<ExecutionResultDto> getExecutionResult(@PathVariable UUID implId, @PathVariable UUID resultId) {
         LOG.debug("Get to retrieve execution result with id: {}.", resultId);

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
@@ -23,7 +23,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.ExecutionResult;
 import org.planqk.nisq.analyzer.core.model.Implementation;
@@ -47,7 +49,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to retrieve the results of quantum algorithm implementation executions.
  */
-@io.swagger.v3.oas.annotations.tags.Tag(name = "execution-result")
+@Tag(name = "execution-result")
 @RestController
 @RequestMapping("/" + Constants.IMPLEMENTATIONS + "/{implId}/" + Constants.RESULTS)
 public class ExecutionResultController {
@@ -62,7 +64,8 @@ public class ExecutionResultController {
         this.executionResultRepository = executionResultRepository;
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve all execution results for an Implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve all execution results for an Implementation")
     @GetMapping("/")
     public HttpEntity<ExecutionResultListDto> getExecutionResults(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve all execution results for impl with id: {}.", implId);
@@ -84,7 +87,8 @@ public class ExecutionResultController {
         return new ResponseEntity<>(dtoList, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single execution result")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve a single execution result")
     @GetMapping("/{resultId}")
     public HttpEntity<ExecutionResultDto> getExecutionResult(@PathVariable UUID implId, @PathVariable UUID resultId) {
         LOG.debug("Get to retrieve execution result with id: {}.", resultId);

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ExecutionResultController.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,6 +52,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  */
 @Tag(name = "execution-result")
 @RestController
+@CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.IMPLEMENTATIONS + "/{implId}/" + Constants.RESULTS)
 public class ExecutionResultController {
 

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
@@ -59,6 +59,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -193,15 +194,15 @@ public class ImplementationController {
 
     @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", content = @Content)},
             description = "Update an implementation")
-    @PostMapping("/{implId}")
+    @PutMapping("/{implId}")
     public HttpEntity<ImplementationDto> updateImplementation(@PathVariable UUID implId, @RequestBody ImplementationDto impl) {
-        LOG.debug("Post to create new implementation received.");
+        LOG.debug("Post to update a new implementation received.");
 
         // check consistency of the implementation object
         if (Objects.isNull(impl.getName())
                 || Objects.isNull(impl.getImplementedAlgorithm()) || Objects.isNull(impl.getSelectionRule())
                 || Objects.isNull(impl.getSdk()) || Objects.isNull(impl.getFileLocation())) {
-            LOG.error("Received invalid implementation object for post request: {}", impl.toString());
+            LOG.error("Received invalid implementation object for put request: {}", impl.toString());
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
@@ -299,7 +300,7 @@ public class ImplementationController {
             description = "Remove input parameters from an implementation")
     @DeleteMapping("/{implId}/" +Constants.INPUT_PARAMS)
     public HttpEntity<Void> deleteInputParameters(@PathVariable UUID implId, @RequestBody List<String> names) {
-        LOG.debug("Post to add input parameter on implementation with id: {}.", implId);
+        LOG.debug("Delete to remove input parameter from implementation with id: {}.", implId);
         Optional<Implementation> implementationOptional = implementationRepository.findById(implId);
         if (!implementationOptional.isPresent()) {
             LOG.error("Unable to retrieve implementation with id {} from the repository.", implId);

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.control.NisqAnalyzerControlService;
 import org.planqk.nisq.analyzer.core.knowledge.prolog.PrologFactUpdater;
@@ -62,6 +64,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate implementations of quantum algorithms.
  */
+@io.swagger.v3.oas.annotations.tags.Tag(name = "implementation")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.IMPLEMENTATIONS)
@@ -109,6 +112,7 @@ public class ImplementationController {
         return true;
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve implementations for an algorithm")
     @GetMapping("/")
     public HttpEntity<ImplementationListDto> getImplementations(@RequestParam(required = false) UUID algoId) {
         LOG.debug("Get to retrieve all implementations received.");
@@ -130,6 +134,7 @@ public class ImplementationController {
         return new ResponseEntity<>(dtoList, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve an implementation")
     @GetMapping("/{implId}")
     public HttpEntity<ImplementationDto> getImplementation(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve implementation with id: {}.", implId);
@@ -143,6 +148,7 @@ public class ImplementationController {
         return new ResponseEntity<>(createImplementationDto(implementationOptional.get()), HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Create an implementation")
     @PostMapping("/")
     public HttpEntity<ImplementationDto> createImplementation(@RequestBody ImplementationDto impl) {
         LOG.debug("Post to create new implementation received.");
@@ -176,6 +182,7 @@ public class ImplementationController {
         return new ResponseEntity<>(createImplementationDto(implementation), HttpStatus.CREATED);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve input parameters for an implementation")
     @GetMapping("/{implId}/" + Constants.INPUT_PARAMS)
     public HttpEntity<ParameterListDto> getInputParameters(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve input parameters for implementation with id: {}.", implId);
@@ -196,6 +203,7 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterListDto, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve output parameters for an implementation")
     @GetMapping("/{implId}/" + Constants.OUTPUT_PARAMS)
     public HttpEntity<ParameterListDto> getOutputParameters(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve output parameters for implementation with id: {}.", implId);
@@ -216,6 +224,7 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterListDto, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "400")}, description = "Add input parameters to an implementation")
     @PostMapping("/{implId}/" + Constants.INPUT_PARAMS)
     public HttpEntity<ParameterDto> addInputParameter(@PathVariable UUID implId, @RequestBody ParameterDto parameterDto) {
         LOG.debug("Post to add input parameter on implementation with id: {}.", implId);
@@ -234,6 +243,7 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterDto, HttpStatus.CREATED);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "400")}, description = "Add output parameters to an implementation")
     @PostMapping("/{implId}/" + Constants.OUTPUT_PARAMS)
     public HttpEntity<ParameterDto> addOutputParameter(@PathVariable UUID implId, @RequestBody ParameterDto parameterDto) {
         LOG.debug("Post to add output parameter on implementation with id: {}.", implId);
@@ -252,6 +262,7 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterDto, HttpStatus.CREATED);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "202"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "500")}, description = "Execute an implementation")
     @PostMapping("/{implId}/" + Constants.EXECUTION)
     public HttpEntity<ExecutionResultDto> executeImplementation(@PathVariable UUID implId,
                                                                 @RequestBody ExecutionRequest executionRequest) {

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
@@ -27,7 +27,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.control.NisqAnalyzerControlService;
 import org.planqk.nisq.analyzer.core.knowledge.prolog.PrologFactUpdater;
@@ -64,7 +66,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate implementations of quantum algorithms.
  */
-@io.swagger.v3.oas.annotations.tags.Tag(name = "implementation")
+@Tag(name = "implementation")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.IMPLEMENTATIONS)
@@ -112,7 +114,8 @@ public class ImplementationController {
         return true;
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve implementations for an algorithm")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve implementations for an algorithm")
     @GetMapping("/")
     public HttpEntity<ImplementationListDto> getImplementations(@RequestParam(required = false) UUID algoId) {
         LOG.debug("Get to retrieve all implementations received.");
@@ -134,7 +137,8 @@ public class ImplementationController {
         return new ResponseEntity<>(dtoList, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve an implementation")
     @GetMapping("/{implId}")
     public HttpEntity<ImplementationDto> getImplementation(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve implementation with id: {}.", implId);
@@ -148,7 +152,8 @@ public class ImplementationController {
         return new ResponseEntity<>(createImplementationDto(implementationOptional.get()), HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Create an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400", content = @Content)},
+            description = "Create an implementation")
     @PostMapping("/")
     public HttpEntity<ImplementationDto> createImplementation(@RequestBody ImplementationDto impl) {
         LOG.debug("Post to create new implementation received.");
@@ -182,7 +187,8 @@ public class ImplementationController {
         return new ResponseEntity<>(createImplementationDto(implementation), HttpStatus.CREATED);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve input parameters for an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve input parameters for an implementation")
     @GetMapping("/{implId}/" + Constants.INPUT_PARAMS)
     public HttpEntity<ParameterListDto> getInputParameters(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve input parameters for implementation with id: {}.", implId);
@@ -203,7 +209,8 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterListDto, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve output parameters for an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve output parameters for an implementation")
     @GetMapping("/{implId}/" + Constants.OUTPUT_PARAMS)
     public HttpEntity<ParameterListDto> getOutputParameters(@PathVariable UUID implId) {
         LOG.debug("Get to retrieve output parameters for implementation with id: {}.", implId);
@@ -224,7 +231,8 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterListDto, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "400")}, description = "Add input parameters to an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content),
+            @ApiResponse(responseCode = "400", content = @Content)}, description = "Add input parameters to an implementation")
     @PostMapping("/{implId}/" + Constants.INPUT_PARAMS)
     public HttpEntity<ParameterDto> addInputParameter(@PathVariable UUID implId, @RequestBody ParameterDto parameterDto) {
         LOG.debug("Post to add input parameter on implementation with id: {}.", implId);
@@ -243,7 +251,8 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterDto, HttpStatus.CREATED);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "400")}, description = "Add output parameters to an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "404", content = @Content),
+            @ApiResponse(responseCode = "400", content = @Content)}, description = "Add output parameters to an implementation")
     @PostMapping("/{implId}/" + Constants.OUTPUT_PARAMS)
     public HttpEntity<ParameterDto> addOutputParameter(@PathVariable UUID implId, @RequestBody ParameterDto parameterDto) {
         LOG.debug("Post to add output parameter on implementation with id: {}.", implId);
@@ -262,7 +271,8 @@ public class ImplementationController {
         return new ResponseEntity<>(parameterDto, HttpStatus.CREATED);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "202"), @ApiResponse(responseCode = "404"), @ApiResponse(responseCode = "500")}, description = "Execute an implementation")
+    @Operation(responses = {@ApiResponse(responseCode = "202"), @ApiResponse(responseCode = "404", content = @Content),
+            @ApiResponse(responseCode = "500", content = @Content)}, description = "Execute an implementation")
     @PostMapping("/{implId}/" + Constants.EXECUTION)
     public HttpEntity<ExecutionResultDto> executeImplementation(@PathVariable UUID implId,
                                                                 @RequestBody ExecutionRequest executionRequest) {

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/ImplementationController.java
@@ -45,7 +45,7 @@ import org.planqk.nisq.analyzer.core.web.dtos.entities.ImplementationDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.ImplementationListDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.ParameterDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.ParameterListDto;
-import org.planqk.nisq.analyzer.core.web.dtos.requests.ExecutionRequest;
+import org.planqk.nisq.analyzer.core.web.dtos.requests.ExecutionRequestDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -275,7 +275,7 @@ public class ImplementationController {
             @ApiResponse(responseCode = "500", content = @Content)}, description = "Execute an implementation")
     @PostMapping("/{implId}/" + Constants.EXECUTION)
     public HttpEntity<ExecutionResultDto> executeImplementation(@PathVariable UUID implId,
-                                                                @RequestBody ExecutionRequest executionRequest) {
+                                                                @RequestBody ExecutionRequestDto executionRequestDto) {
         LOG.debug("Post to execute implementation with Id: {}", implId);
 
         Optional<Implementation> implementationOptional = implementationRepository.findById(implId);
@@ -284,14 +284,14 @@ public class ImplementationController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
-        Optional<Qpu> qpuOptional = qpuRepository.findById(executionRequest.getQpuId());
+        Optional<Qpu> qpuOptional = qpuRepository.findById(executionRequestDto.getQpuId());
         if (!qpuOptional.isPresent()) {
-            LOG.error("Unable to retrieve qpu with id {} form the repository.", executionRequest.getQpuId());
+            LOG.error("Unable to retrieve qpu with id {} form the repository.", executionRequestDto.getQpuId());
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
         try {
-            ExecutionResult result = controlService.executeQuantumAlgorithmImplementation(implementationOptional.get(), qpuOptional.get(), executionRequest.getParameters(), executionRequest.getAnalysedDepth(), executionRequest.getAnalysedWidth());
+            ExecutionResult result = controlService.executeQuantumAlgorithmImplementation(implementationOptional.get(), qpuOptional.get(), executionRequestDto.getParameters(), executionRequestDto.getAnalysedDepth(), executionRequestDto.getAnalysedWidth());
             ExecutionResultDto dto = ExecutionResultDto.Converter.convert(result);
             dto.add(linkTo(methodOn(ExecutionResultController.class).getExecutionResult(implId, result.getId())).withSelfRel());
             return new ResponseEntity<>(dto, HttpStatus.ACCEPTED);

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.knowledge.prolog.PrologFactUpdater;
 import org.planqk.nisq.analyzer.core.model.Qpu;
@@ -53,6 +55,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate quantum processing units (QPUs).
  */
+@io.swagger.v3.oas.annotations.tags.Tag(name = "qpu")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.QPUS)
@@ -69,6 +72,7 @@ public class QpuController {
         this.prologFactUpdater = prologFactUpdater;
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Retrieve all QPUs")
     @GetMapping("/")
     public HttpEntity<QpuListDto> getQpus() {
         LOG.debug("Get to retrieve all QPUs received.");
@@ -84,6 +88,7 @@ public class QpuController {
         return new ResponseEntity<>(qpuListDto, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single QPU")
     @GetMapping("/{qpuId}")
     public HttpEntity<QpuDto> getQpu(@PathVariable UUID qpuId) {
         LOG.debug("Get to retrieve QPU with id: {}.", qpuId);
@@ -97,6 +102,7 @@ public class QpuController {
         return new ResponseEntity<>(createQpuDto(qpuOptional.get()), HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Create a QPU")
     @PostMapping("/")
     public HttpEntity<QpuDto> createQpu(@RequestBody CreateQpuRequest qpuRequest) {
         LOG.debug("Post to create new QPU received.");
@@ -124,7 +130,7 @@ public class QpuController {
         // store and return QPU
         Qpu qpu = qpuRepository.save(QpuDto.Converter.convert(qpuRequest, supportedSdks));
         prologFactUpdater.handleQpuInsertion(qpu);
-        return new ResponseEntity<>(createQpuDto(qpu), HttpStatus.OK);
+        return new ResponseEntity<>(createQpuDto(qpu), HttpStatus.CREATED);
     }
 
     /**

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
@@ -37,7 +37,7 @@ import org.planqk.nisq.analyzer.core.repository.QpuRepository;
 import org.planqk.nisq.analyzer.core.repository.SdkRepository;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.QpuDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.QpuListDto;
-import org.planqk.nisq.analyzer.core.web.dtos.requests.CreateQpuRequest;
+import org.planqk.nisq.analyzer.core.web.dtos.requests.CreateQpuRequestDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -108,7 +108,7 @@ public class QpuController {
     @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400", content = @Content)},
             description = "Create a QPU")
     @PostMapping("/")
-    public HttpEntity<QpuDto> createQpu(@RequestBody CreateQpuRequest qpuRequest) {
+    public HttpEntity<QpuDto> createQpu(@RequestBody CreateQpuRequestDto qpuRequest) {
         LOG.debug("Post to create new QPU received.");
 
         // check consistency of the QPU object

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/QpuController.java
@@ -26,7 +26,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.knowledge.prolog.PrologFactUpdater;
 import org.planqk.nisq.analyzer.core.model.Qpu;
@@ -55,7 +57,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate quantum processing units (QPUs).
  */
-@io.swagger.v3.oas.annotations.tags.Tag(name = "qpu")
+@Tag(name = "qpu")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.QPUS)
@@ -88,7 +90,8 @@ public class QpuController {
         return new ResponseEntity<>(qpuListDto, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single QPU")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve a single QPU")
     @GetMapping("/{qpuId}")
     public HttpEntity<QpuDto> getQpu(@PathVariable UUID qpuId) {
         LOG.debug("Get to retrieve QPU with id: {}.", qpuId);
@@ -102,7 +105,8 @@ public class QpuController {
         return new ResponseEntity<>(createQpuDto(qpuOptional.get()), HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Create a QPU")
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400", content = @Content)},
+            description = "Create a QPU")
     @PostMapping("/")
     public HttpEntity<QpuDto> createQpu(@RequestBody CreateQpuRequest qpuRequest) {
         LOG.debug("Post to create new QPU received.");

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
@@ -35,7 +35,7 @@ import org.planqk.nisq.analyzer.core.web.dtos.entities.AnalysisResultDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.AnalysisResultListDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.ParameterDto;
 import org.planqk.nisq.analyzer.core.web.dtos.entities.ParameterListDto;
-import org.planqk.nisq.analyzer.core.web.dtos.requests.SelectionRequest;
+import org.planqk.nisq.analyzer.core.web.dtos.requests.SelectionRequestDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.hateoas.RepresentationModel;
@@ -88,12 +88,12 @@ public class RootController {
     @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", content = @Content)},
             description = "Retrieve selection parameters")
     @GetMapping("/" + Constants.SELECTION_PARAMS)
-    public ResponseEntity getSelectionParams(@RequestParam UUID algoId) {
+    public HttpEntity<ParameterListDto> getSelectionParams(@RequestParam UUID algoId) {
         LOG.debug("Get to retrieve selection parameters for algorithm with Id {} received.", algoId);
 
         if (Objects.isNull(algoId)) {
             LOG.error("AlgoId have to be provided to get selection parameters!");
-            return new ResponseEntity<>("AlgoId have to be provided to get selection parameters!", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity("AlgoId have to be provided to get selection parameters!", HttpStatus.BAD_REQUEST);
         }
 
         // determine and return required selection parameters
@@ -111,17 +111,17 @@ public class RootController {
     @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", content = @Content),
             @ApiResponse(responseCode = "500", content = @Content)}, description = "Select implementations for an algorithm")
     @PostMapping("/" + Constants.SELECTION)
-    public ResponseEntity selectImplementations(@RequestBody SelectionRequest params) {
+    public HttpEntity<AnalysisResultListDto> selectImplementations(@RequestBody SelectionRequestDto params) {
         LOG.debug("Post to select implementations for algorithm with Id {} received.", params.getAlgorithmId());
 
         if (Objects.isNull(params.getAlgorithmId())) {
             LOG.error("Algorithm Id for the selection is null.");
-            return new ResponseEntity<>("Algorithm Id for the selection is null.", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity("Algorithm Id for the selection is null.", HttpStatus.BAD_REQUEST);
         }
 
         if (Objects.isNull(params.getParameters())) {
             LOG.error("Parameter set for the selection is null.");
-            return new ResponseEntity<>("Parameter set for the selection is null.", HttpStatus.BAD_REQUEST);
+            return new ResponseEntity("Parameter set for the selection is null.", HttpStatus.BAD_REQUEST);
         }
         LOG.debug("Received {} parameters for the selection.", params.getParameters().size());
 
@@ -130,7 +130,7 @@ public class RootController {
             analysisResults = nisqAnalyzerService.performSelection(params.getAlgorithmId(), params.getParameters());
         } catch (UnsatisfiedLinkError e) {
             LOG.error("UnsatisfiedLinkError while activating prolog rule. Please make sure prolog is installed and configured correctly to use the NISQ analyzer functionality!");
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("No prolog engine accessible from the server. Selection not possible!");
+            return new ResponseEntity("No prolog engine accessible from the server. Selection not possible!", HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         AnalysisResultListDto analysisResultListDto = new AnalysisResultListDto();

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.AnalysisResult;
 import org.planqk.nisq.analyzer.core.control.NisqAnalyzerControlService;
@@ -52,6 +54,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * Root controller to access all entities within Quality, trigger the hardware selection, and execution of quantum
  * algorithms.
  */
+@io.swagger.v3.oas.annotations.tags.Tag(name = "root")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 public class RootController {
@@ -64,6 +67,7 @@ public class RootController {
         this.nisqAnalyzerService = nisqAnalyzerService;
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Root operation, returns further links")
     @GetMapping("/")
     public HttpEntity<RepresentationModel> root() {
         RepresentationModel responseEntity = new RepresentationModel<>();
@@ -79,6 +83,7 @@ public class RootController {
         return new ResponseEntity<>(responseEntity, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400")}, description = "Retrieve selection parameters")
     @GetMapping("/" + Constants.SELECTION_PARAMS)
     public ResponseEntity getSelectionParams(@RequestParam UUID algoId) {
         LOG.debug("Get to retrieve selection parameters for algorithm with Id {} received.", algoId);
@@ -100,6 +105,7 @@ public class RootController {
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"), @ApiResponse(responseCode = "500")}, description = "Select implementations for an algorithm")
     @PostMapping("/" + Constants.SELECTION)
     public ResponseEntity selectImplementations(@RequestBody SelectionRequest params) {
         LOG.debug("Post to select implementations for algorithm with Id {} received.", params.getAlgorithmId());

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/RootController.java
@@ -25,7 +25,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.AnalysisResult;
 import org.planqk.nisq.analyzer.core.control.NisqAnalyzerControlService;
@@ -54,7 +56,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * Root controller to access all entities within Quality, trigger the hardware selection, and execution of quantum
  * algorithms.
  */
-@io.swagger.v3.oas.annotations.tags.Tag(name = "root")
+@Tag(name = "root")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 public class RootController {
@@ -83,7 +85,8 @@ public class RootController {
         return new ResponseEntity<>(responseEntity, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400")}, description = "Retrieve selection parameters")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", content = @Content)},
+            description = "Retrieve selection parameters")
     @GetMapping("/" + Constants.SELECTION_PARAMS)
     public ResponseEntity getSelectionParams(@RequestParam UUID algoId) {
         LOG.debug("Get to retrieve selection parameters for algorithm with Id {} received.", algoId);
@@ -105,7 +108,8 @@ public class RootController {
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400"), @ApiResponse(responseCode = "500")}, description = "Select implementations for an algorithm")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "400", content = @Content),
+            @ApiResponse(responseCode = "500", content = @Content)}, description = "Select implementations for an algorithm")
     @PostMapping("/" + Constants.SELECTION)
     public ResponseEntity selectImplementations(@RequestBody SelectionRequest params) {
         LOG.debug("Post to select implementations for algorithm with Id {} received.", params.getAlgorithmId());

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/SdkController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/SdkController.java
@@ -24,7 +24,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.Sdk;
 import org.planqk.nisq.analyzer.core.repository.SdkRepository;
@@ -49,7 +51,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate software development kits (SDKs).
  */
-@io.swagger.v3.oas.annotations.tags.Tag(name = "sdks")
+@Tag(name = "sdks")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.SDKS)
@@ -79,7 +81,8 @@ public class SdkController {
         return new ResponseEntity<>(sdkListDto, HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single SDK")
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404", content = @Content)},
+            description = "Retrieve a single SDK")
     @GetMapping("/{id}")
     public HttpEntity<SdkDto> getSdk(@PathVariable UUID id) {
         LOG.debug("Get to retrieve SDK with id: {}.", id);
@@ -93,7 +96,8 @@ public class SdkController {
         return new ResponseEntity<>(createSdkDto(sdkOptional.get()), HttpStatus.OK);
     }
 
-    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Creates a new SDK")
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400", content = @Content)},
+            description = "Creates a new SDK")
     @PostMapping("/")
     public HttpEntity<SdkDto> createSDK(@RequestBody SdkDto sdkDto) {
         LOG.debug("Post to create new Sdk received.");

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/SdkController.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/controller/SdkController.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.planqk.nisq.analyzer.core.Constants;
 import org.planqk.nisq.analyzer.core.model.Sdk;
 import org.planqk.nisq.analyzer.core.repository.SdkRepository;
@@ -47,6 +49,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 /**
  * Controller to access and manipulate software development kits (SDKs).
  */
+@io.swagger.v3.oas.annotations.tags.Tag(name = "sdks")
 @RestController
 @CrossOrigin(allowedHeaders = "*", origins = "*")
 @RequestMapping("/" + Constants.SDKS)
@@ -60,6 +63,7 @@ public class SdkController {
         this.sdkRepository = sdkRepository;
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Retrieve all SDKs")
     @GetMapping("/")
     public HttpEntity<SdkListDto> getSdks() {
         LOG.debug("Get to retrieve all SDKs received.");
@@ -75,6 +79,7 @@ public class SdkController {
         return new ResponseEntity<>(sdkListDto, HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "404")}, description = "Retrieve a single SDK")
     @GetMapping("/{id}")
     public HttpEntity<SdkDto> getSdk(@PathVariable UUID id) {
         LOG.debug("Get to retrieve SDK with id: {}.", id);
@@ -88,8 +93,9 @@ public class SdkController {
         return new ResponseEntity<>(createSdkDto(sdkOptional.get()), HttpStatus.OK);
     }
 
+    @Operation(responses = {@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "400")}, description = "Creates a new SDK")
     @PostMapping("/")
-    public HttpEntity<SdkDto> createImplementation(@RequestBody SdkDto sdkDto) {
+    public HttpEntity<SdkDto> createSDK(@RequestBody SdkDto sdkDto) {
         LOG.debug("Post to create new Sdk received.");
 
         if (Objects.isNull(sdkDto.getName())) {

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/CreateQpuRequestDto.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/CreateQpuRequestDto.java
@@ -19,25 +19,20 @@
 
 package org.planqk.nisq.analyzer.core.web.dtos.requests;
 
+import java.util.List;
 import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.planqk.nisq.analyzer.core.model.Qpu;
+import org.planqk.nisq.analyzer.core.web.dtos.entities.QpuDto;
 
 /**
- * Dto to exchange input and output parameters as key value pairs.
+ * Request object which is passed to create a new {@link Qpu}.
  */
-public class ExecutionRequest extends ParameterKeyValueDto {
+public class CreateQpuRequestDto extends QpuDto {
 
     @Getter
     @Setter
-    private UUID qpuId;
-
-    @Getter
-    @Setter
-    private int analysedDepth;
-
-    @Getter
-    @Setter
-    private int analysedWidth;
+    private List<UUID> supportedSdkIds;
 }

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/ExecutionRequestDto.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/ExecutionRequestDto.java
@@ -24,9 +24,20 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 
-public class SelectionRequest extends ParameterKeyValueDto {
+/**
+ * Dto to exchange input and output parameters as key value pairs.
+ */
+public class ExecutionRequestDto extends ParameterKeyValueDto {
 
     @Getter
     @Setter
-    private UUID algorithmId;
+    private UUID qpuId;
+
+    @Getter
+    @Setter
+    private int analysedDepth;
+
+    @Getter
+    @Setter
+    private int analysedWidth;
 }

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/SelectionRequestDto.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/SelectionRequestDto.java
@@ -19,20 +19,14 @@
 
 package org.planqk.nisq.analyzer.core.web.dtos.requests;
 
-import java.util.List;
 import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.planqk.nisq.analyzer.core.model.Qpu;
-import org.planqk.nisq.analyzer.core.web.dtos.entities.QpuDto;
 
-/**
- * Request object which is passed to create a new {@link Qpu}.
- */
-public class CreateQpuRequest extends QpuDto {
+public class SelectionRequestDto extends ParameterKeyValueDto {
 
     @Getter
     @Setter
-    private List<UUID> supportedSdkIds;
+    private UUID algorithmId;
 }

--- a/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
+++ b/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
@@ -21,4 +21,5 @@ NISQ_PORT=5000
 NISQ_VERSION=v1.0
 
 # Embedded Tomcat
+server.port=8081
 server.servlet.contextPath=/nisq-analyzer

--- a/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
+++ b/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
@@ -1,18 +1,23 @@
 spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/nisq
+spring.datasource.username=nisq
+spring.datasource.password=nisq
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.hibernate.ddl-auto=update
 logging.level.org.planqk.nisq=DEBUG
 springdoc.swagger-ui.path=/swagger-ui
-springdoc.swagger-ui.config-url=/nisq-analyzer/v3/api-docs/
+springdoc.swagger-ui.config-url=/nisq-analyzer/v3/api-docs/swagger-config
+springdoc.api-docs.groups.enabled=true
+springdoc.swagger-ui.url=/nisq-analyzer/v3/api-docs
+springdoc.swagger-ui.operationsSorter=alpha
 spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
-
 
 # SDK Connector configuration
 org.planqk.nisq.analyzer.connector.qiskit.hostname=127.0.0.1
 org.planqk.nisq.analyzer.connector.qiskit.port=5000
 org.planqk.nisq.analyzer.connector.qiskit.version=v1.0
+
+# Embedded Tomcat
+server.servlet.contextPath=/nisq-analyzer

--- a/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
+++ b/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
@@ -13,6 +13,7 @@ springdoc.swagger-ui.url=/nisq-analyzer/v3/api-docs
 springdoc.swagger-ui.operationsSorter=alpha
 spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+springdoc.default-produces-media-type=application/hal+json
 
 # SDK Connector configuration
 NISQ_HOSTNAME=127.0.0.1

--- a/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
+++ b/org.planqk.nisq.analyzer.core/src/main/resources/application.properties
@@ -15,9 +15,9 @@ spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 # SDK Connector configuration
-org.planqk.nisq.analyzer.connector.qiskit.hostname=127.0.0.1
-org.planqk.nisq.analyzer.connector.qiskit.port=5000
-org.planqk.nisq.analyzer.connector.qiskit.version=v1.0
+NISQ_HOSTNAME=127.0.0.1
+NISQ_PORT=5000
+NISQ_VERSION=v1.0
 
 # Embedded Tomcat
 server.servlet.contextPath=/nisq-analyzer

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,12 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.2.31</version>
+            <version>1.3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-data-rest</artifactId>
+            <version>1.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
#### Short Description
Adds OpenAPI support to enable clients to generate services.
Furthermore, embedded Tomcat is added + db credentials changed to support the concurrent execution of the nisq analyzer and qc-atlas.

Related to [Issue #50](https://github.com/PlanQK/q-tal/issues/50)