### PR TITLE
Handling 'too many qubits' error returned by Qiskit service.

### DIFF
--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/connector/CircuitInformation.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/connector/CircuitInformation.java
@@ -41,4 +41,17 @@ public class CircuitInformation {
     @Setter
     @JsonProperty("width")
     private int circuitWidth = 0;
+
+    @Getter
+    @Setter
+    private String error;
+
+    /**
+     * Returns whether the transpilation was successfull
+     * @return
+     */
+    public boolean wasTranspilationSuccessfull()
+    {
+        return this.error == null;
+    }
 }

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/control/NisqAnalyzerControlService.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/control/NisqAnalyzerControlService.java
@@ -193,6 +193,8 @@ public class NisqAnalyzerControlService {
 
                 // analyze the quantum circuit by utilizing the capabilities of the suited plugin and retrieve important circuit properties
                 CircuitInformation circuitInformation = selectedSdkConnector.getCircuitProperties(execImplementation.getFileLocation(), qpu, execInputParameters);
+
+                // fall back to estimates if something unexpected happened
                 if (Objects.isNull(circuitInformation)) {
                     LOG.error("Circuit analysis by compiler failed. Using estimates...");
 
@@ -200,6 +202,13 @@ public class NisqAnalyzerControlService {
                     if (estimatedCircuitDepth != 0 && estimatedQubitCount != 0) {
                         analysisResult.add(new AnalysisResult(qpu, execImplementation, true, estimatedCircuitDepth, estimatedQubitCount));
                     }
+                    continue;
+                }
+
+                // skip qpu if some (expected) error occured during transpilation,
+                // e.g. too many qubits required or the input wasn't suitable for the implementation
+                if (!circuitInformation.wasTranspilationSuccessfull()) {
+                    LOG.error("Transpilation of circuit impossible: {}. Skipping Qpu.", circuitInformation.getError());
                     continue;
                 }
 


### PR DESCRIPTION
#### Short Description
In case too many qubits are required, the Qiskit Services returns HTTP code 200, but content { "error" : "..."}.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * CircuitInformation DTO is expanded to also handle this case
  * Check during implementation selection if the returned CircuitInformation contains an error message.

**Fixes**: #15 
