### PR TITLE
Bug/16

### DIFF
--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/control/NisqAnalyzerControlService.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/control/NisqAnalyzerControlService.java
@@ -329,7 +329,7 @@ public class NisqAnalyzerControlService {
 
         return parameters.entrySet().stream().map(
                 // map parameters that are defined in the implementation
-                e -> new EntryParameterPair(e, implementation.getInputParameters().stream().filter(p -> p.getName().equals(e.getValue())).findFirst())
+                e -> new EntryParameterPair(e, implementation.getInputParameters().stream().filter(p -> p.getName().equals(e.getKey())).findFirst())
         ).filter(
                 // filter undefined parameters
                 e -> e.getParameter().isPresent()


### PR DESCRIPTION
#### Short Description
Use implementation's type information to create proper Prolog literals. Closes #16.

#### Proposed Changes

  * Match provided parameters to implementation definition in order to identify type
  * Use type information to create correctly typed Prolog literals during replacement phase
  * Works for string and integers (tested) 

**Fixes**: #16 
