### PR TITLE
Add the option to pass the QASM code as a string instead of an URL

### DIFF
--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/CompilerSelectionDto.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/CompilerSelectionDto.java
@@ -36,6 +36,8 @@ public class CompilerSelectionDto {
 
     URL circuitUrl;
 
+    String qasmCode;
+
     String token;
 
     String refreshToken;

--- a/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/QpuSelectionDto.java
+++ b/org.planqk.nisq.analyzer.core/src/main/java/org/planqk/nisq/analyzer/core/web/dtos/requests/QpuSelectionDto.java
@@ -34,6 +34,8 @@ public class QpuSelectionDto {
 
     URL circuitUrl;
 
+    String qasmCode;
+
     Map<String, String> tokens;
 
     String refreshToken;


### PR DESCRIPTION
#### Short Description
Add the option to pass the QASM code as a string instead of an URL.

#### Proposed Changes

  * new field in the request body for QPU and compiler selection
  * either the URL or QASM string needs to be present in the request

#### Todo

These changes should to be tested with real data.